### PR TITLE
Fix dependency conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name         = 'shub-workflow',
-    version      = '1.5.2',
+    version      = '1.5.3',
     description  = 'Workflow manager for scrapinghub ScrapyCloud tasks.',
     long_description = open('README.md').read(),
     license      = 'BSD',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'jinja2>=2.7.3',
         'sqlitedict==1.6.0',
         's3fs==0.2.0',
-        'botocore==1.12.91',
+        'botocore==1.12.92',
         'msgpack-python',
     ),
     scripts = [],


### PR DESCRIPTION
Hi @kalessin 

It would seem that the commit in https://github.com/scrapinghub/shub-workflow/commit/9d0684c236934186a030f5bd1a606faf95f0f488 have broke our builds due to the some dependency conflicts described below:

```
- shub-workflow [required: >=1.5.1]
  - botocore [required: ==1.12.91]
  - s3fs [required: ==0.2.0]
    - boto3 [required: Any]
      - botocore [required: >=1.12.92,<1.13.0]
```

As can be seen from the dependency graph above, `botocore` from `shub-workflow` should be bumped to at least **1.12.92** in order to match the `botocore >=1.12.92,<1.13.0` that is required for `boto3`.

This PR intends to bump the `botocore` version to prevent such dependency conflicts.

I've also updated the version of this package so we could release this as soon as possible. 

Please let me know if I could assist in some steps.

Cheers!