### PR TITLE
Avoid duplicate scheduling of scripts

### DIFF
--- a/shub_workflow/script.py
+++ b/shub_workflow/script.py
@@ -159,7 +159,7 @@ class BaseScript(abc.ABC):
             job = project.jobs.run(**schedule_kwargs)
         except DuplicateJobError as e:
             logger.error(str(e))
-        except:
+        except Exception:
             raise
         else:
             logger.info(f"Scheduled job {job.key}")

--- a/shub_workflow/script.py
+++ b/shub_workflow/script.py
@@ -1,19 +1,20 @@
 """
 Implements common methods for ScrapyCloud scripts.
 """
-import os
-import abc
-import logging
-from typing import List
 
+import abc
+import json
+import logging
+import os
+import subprocess
 from argparse import ArgumentParser
+from typing import List
 
 from scrapinghub import ScrapinghubClient, DuplicateJobError
 
 from .utils import (
     resolve_project_id,
     dash_retry_decorator,
-    schedule_script_in_dash,
 )
 
 
@@ -144,29 +145,48 @@ class BaseScript(abc.ABC):
             tags.append(f'FLOW_ID={self.flow_id}')
         return list(set(tags)) or None
 
-    def schedule_script(self, cmd: List[str], tags=None, project_id=None, **kwargs):
-        """
-        Schedules an external script
-        """
-        logger.info('Starting: {}'.format(cmd))
-        project = self.get_project(project_id)
-        job = schedule_script_in_dash(project, [str(x) for x in cmd], tags=self._make_tags(tags), **kwargs)
-        logger.info(f"Scheduled script job {job.key}")
-        return job.key
-
     @dash_retry_decorator
-    def schedule_spider(self, spider: str, tags=None, units=None, project_id=None, **spiderargs):
-        schedule_kwargs = dict(spider=spider, add_tag=self._make_tags(tags), units=units, **spiderargs)
-        logger.info("Scheduling a spider:\n%s", schedule_kwargs)
+    def _schedule_job(self, spider: str, tags=None, units=None, project_id=None, **kwargs):
+        project = self.get_project(project_id)
+        schedule_kwargs = dict(
+            spider=spider,
+            add_tag=self._make_tags(tags),
+            units=units,
+            **kwargs,
+        )
+        logger.info("Scheduling a job:\n%s", schedule_kwargs)
         try:
-            project = self.get_project(project_id)
             job = project.jobs.run(**schedule_kwargs)
-            logger.info(f"Scheduled spider job {job.key}")
-            return job.key
         except DuplicateJobError as e:
             logger.error(str(e))
         except:
             raise
+        else:
+            logger.info(f"Scheduled job {job.key}")
+            return job.key
+
+    def schedule_script(self, cmd: List[str], tags=None, project_id=None, units=None, meta=None):
+        cmd = [str(x) for x in cmd]
+        scriptname = cmd[0]
+        if not scriptname.startswith('py:'):
+            scriptname = 'py:' + scriptname
+        return self._schedule_job(
+            spider=scriptname,
+            tags=tags,
+            units=units,
+            project_id=project_id,
+            cmd_args=subprocess.list2cmdline(cmd[1:]),
+            meta=json.dumps(meta) if meta else None,
+        )
+
+    def schedule_spider(self, spider: str, tags=None, units=None, project_id=None, **kwargs):
+        return self._schedule_job(
+            spider=spider,
+            tags=tags,
+            units=units,
+            project_id=project_id,
+            **kwargs,
+        )
 
     @dash_retry_decorator
     def get_jobs(self, project_id=None, **kwargs):

--- a/shub_workflow/utils.py
+++ b/shub_workflow/utils.py
@@ -3,8 +3,6 @@ import os
 
 from retrying import retry
 
-from scrapinghub import APIError
-from scrapinghub.client.exceptions import DuplicateJobError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -39,7 +37,7 @@ def resolve_project_id(project_id=None):
         project_id = cfg.get_project_id('default')
         if project_id:
             return project_id
-    except:
+    except Exception:
         logger.warning("Install shub package if want to access scrapinghub.yml")
 
     if not project_id:

--- a/shub_workflow/utils.py
+++ b/shub_workflow/utils.py
@@ -48,12 +48,6 @@ MINS_IN_A_DAY = 24 * 60
 ONE_MIN_IN_S = 60
 
 
-class _DontRetry(RuntimeError):
-
-    def __init__(self, exception):
-        self.exception = exception
-
-
 def just_log_exception(exception):
     logger.error(repr(exception))
     for etype in (KeyboardInterrupt, SystemExit, ImportError):

--- a/shub_workflow/utils.py
+++ b/shub_workflow/utils.py
@@ -1,10 +1,10 @@
-import os
 import logging
-import json
-import subprocess
+import os
+
 from retrying import retry
 
 from scrapinghub import APIError
+from scrapinghub.client.exceptions import DuplicateJobError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -50,46 +50,24 @@ MINS_IN_A_DAY = 24 * 60
 ONE_MIN_IN_S = 60
 
 
+class _DontRetry(RuntimeError):
+
+    def __init__(self, exception):
+        self.exception = exception
+
+
 def just_log_exception(exception):
-    logger.error(str(exception))
+    logger.error(repr(exception))
     for etype in (KeyboardInterrupt, SystemExit, ImportError):
         if isinstance(exception, etype):
             return False
+
     logger.info("Waiting %d seconds", ONE_MIN_IN_S)
     return True  # retries any other exception
 
 
 dash_retry_decorator = retry(retry_on_exception=just_log_exception, wait_fixed=ONE_MIN_IN_S*1000,
                              stop_max_attempt_number=MINS_IN_A_DAY)
-
-
-@dash_retry_decorator
-def schedule_script_in_dash(shubproject, cmd, tags=None, units=None, meta=None):
-    """
-    :type shubproject: scrapinghub.Project
-    shubproject - an instance of python-scrapinghub project
-    cmd - command line list. First element is script name and rest are options and arguments
-    tags - a list of tags to be added to the job
-    units - how many Kumo units assign to the job
-    meta - a dict with metadata to add to job metadata
-    """
-    tags = tags or []
-    meta = json.dumps(meta) if meta else None
-    # lock = str(hash(tuple(cmd))) lock is still not a feature of dash schedule api
-    scriptname = cmd[0]
-    if not scriptname.startswith('py:'):
-        scriptname = 'py:' + scriptname
-    try:
-        cmd_args = subprocess.list2cmdline(cmd[1:])
-        schedule_kwargs = dict(
-            spider=scriptname, cmd_args=cmd_args, add_tag=tags, units=units, meta=None)
-        logger.info("Scheduling script:\n%s", schedule_kwargs)
-        return shubproject.jobs.run(**schedule_kwargs)
-    except APIError as e:
-        raise RuntimeError(
-            "Error scheduling script %s in %s: %s",
-            scriptname, shubproject.id, str(e),
-        )
 
 
 def kumo_settings():


### PR DESCRIPTION
When the first API request to schedule a script fails due to a request timeout, but the script job is successfully scheduled in Scrapy Cloud, the current implementation retries the script job scheduling, getting bad responses about the job being a duplicate of an existing one until the previously-scheduled job finishes. Then, a duplicate job is created.

I noticed that the counterpart implementation for spiders has a check in place to avoid this issue: if the API reports that the job is a duplicate of a running job, there are no more retries. There is no reason for this approach not to be also taken for scripts.

So I’ve extracted `schedule_spider` into `_schedule_job`, removed the unnecessary ‘spider’ references in log messages, and reimplemented `schedule_script` to use `_schedule_job`.

These changes include an API change, the removal of `shub_workflow.utils.schedule_script_in_dash` (which was also available at `shub_workflow.script.schedule_script_in_dash`).

CC: @hermit-crab (he discovered and diagnosed the original issue)