### PR TITLE
Use new .list_iter() method of sh client to avoid issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,11 @@ setup(
     install_requires = (
         'pyyaml>=3.12',
         'retrying>=1.3.3',
-        'scrapinghub>=2.0.3',
+        'scrapinghub[msgpack]>=2.3.1',
         'jinja2>=2.7.3',
         'sqlitedict==1.6.0',
         's3fs==0.2.0',
         'boto3>=1.9.92',
-        'msgpack-python',
     ),
     scripts = [],
     classifiers = [


### PR DESCRIPTION
Allow for better memory/performance tweaking and avoid:
- https://github.com/scrapinghub/shub-workflow/issues/5
- https://github.com/scrapinghub/python-scrapinghub/issues/121
- https://github.com/scrapinghub/python-scrapinghub/issues/141
