### PR TITLE
Save stats keys as keys of the collection item

### DIFF
--- a/shub_workflow/utils/monitor.py
+++ b/shub_workflow/utils/monitor.py
@@ -434,7 +434,7 @@ that can be recognized by dateparser.""",
         end_dt_str = end_dt.strftime("%Y-%m-%d")
 
         key = start_dt_str if time_delta == 86400 else f"{start_dt_str} to {end_dt_str}"
-        collection.set({"_key": key, "value": stats})
+        collection.set({"_key": key, **stats})
 
     def close(self):
         self.send_messages()


### PR DESCRIPTION
Stats are now saved to Scrapy Cloud collections using the stat keys as keys of the collection item.

Stat item before:
```
{
    "_key": "2026-06-29",
    "value": {
        "stat_name": 1,
        ...
    }
}
```

Stat name after:
```
{
    "_key": "2026-06-29",
    "stat_name": 1,
    ...
}
```